### PR TITLE
feat: 增加VRAM清理时模型卸载状态的输出

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -49,6 +49,10 @@ class VRAMCleanup:
         try:
             if offload_model:
                 comfy.model_management.unload_all_models()
+                if len(comfy.model_management.loaded_models) == 0:
+                    print("模型卸载成功")
+                else:
+                    print("模型卸载失败")
             
             if offload_cache:
                 gc.collect()


### PR DESCRIPTION
## 改动内容
在 VRAMCleanup 节点执行模型卸载时，增加卸载状态的输出信息。

- 卸载成功：输出 `模型卸载成功`
- 卸载失败：输出 `模型卸载失败`

## 相关 Issue
关联 #8 [[建议] VRAM清理时增加模型卸载状态的输出信息](https://github.com/LAOGOU-666/Comfyui-Memory_Cleanup/issues/8)